### PR TITLE
fix Swift 1.2 warnings shown in Xcode7.3

### DIFF
--- a/EPContactsPicker/EPContactsPicker.swift
+++ b/EPContactsPicker/EPContactsPicker.swift
@@ -69,11 +69,11 @@ public class EPContactsPicker: UITableViewController, UISearchResultsUpdating, U
     }
     
     func inititlizeBarButtons() {
-        let cancelButton = UIBarButtonItem(barButtonSystemItem: UIBarButtonSystemItem.Cancel, target: self, action: "onTouchCancelButton")
+        let cancelButton = UIBarButtonItem(barButtonSystemItem: UIBarButtonSystemItem.Cancel, target: self, action: #selector(onTouchCancelButton))
         self.navigationItem.leftBarButtonItem = cancelButton
         
         if multiSelectEnabled {
-            let doneButton = UIBarButtonItem(barButtonSystemItem: UIBarButtonSystemItem.Done, target: self, action: "onTouchDoneButton")
+            let doneButton = UIBarButtonItem(barButtonSystemItem: UIBarButtonSystemItem.Done, target: self, action: #selector(onTouchDoneButton))
             self.navigationItem.rightBarButtonItem = doneButton
             
         }

--- a/EPContactsPicker/EPExtensions.swift
+++ b/EPContactsPicker/EPExtensions.swift
@@ -18,7 +18,7 @@ extension String {
             }
             let startIndex = self.startIndex.advancedBy(r.startIndex)
             let endIndex = self.startIndex.advancedBy(r.endIndex - r.startIndex)
-            return self[Range(start: startIndex, end: endIndex)]
+            return self[(startIndex ..< endIndex)]
         }
     }
     


### PR DESCRIPTION
Thank you for very helpful Cocoapod!

We use it with Xcode7.3 and have see these warnings:
```
EPContactsPicker/EPContactsPicker.swift:72:117: Use of string literal for Objective-C selectors is deprecated; use '#selector' instead

EPContactsPicker/EPContactsPicker.swift:76:117: Use of string literal for Objective-C selectors is deprecated; use '#selector' instead

EPContactsPicker/EPExtensions.swift:21:25: 'init(start:end:)' is deprecated: it will be removed in Swift 3.  Use the '..<' operator.
```

This is proposed fix for them. Thank you!