### PR TITLE
fix travis build to pass on latest Xcode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ before_install:
   - xctool version
 script:
   - xctool clean build
-  - xctool test
+  - xctool test -test-sdk iphonesimulator -resetSimulator

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ xcode_sdk: iphonesimulator                # iphonesimulator9.3
 before_install:
   - xcodebuild -version
 script:
-  - set -o pipefail
-  - COMMAND="xcodebuild -project \"$TRAVIS_XCODE_PROJECT\" -scheme \"$TRAVIS_XCODE_SCHEME\" -destination \"platform=iOS Simulator,name=iPhone 6s,OS=9.3\""
+  - DESTINATION="-destination \"platform=iOS Simulator,name=iPhone 6s,OS=latest\""
+  - COMMAND="xcodebuild -project \"$TRAVIS_XCODE_PROJECT\" -scheme \"$TRAVIS_XCODE_SCHEME\" $DESTINATION"
   - eval $COMMAND clean build &>/dev/null
+  - set -o pipefail
   - eval $COMMAND test | xcpretty

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
-language: objective-c  #1
-osx_image: xcode7.3 #2
-xcode_project: Contacts Picker.xcodeproj #3
-xcode_scheme: Contacts Picker #4
-xcode_sdk: iphonesimulator #5
+language: objective-c                     # https://docs.travis-ci.com/user/languages/objective-c
+osx_image: xcode7.3                       # https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-7.3
+xcode_project: Contacts Picker.xcodeproj  # https://docs.travis-ci.com/user/languages/objective-c#Default-Test-Script
+xcode_scheme: Contacts Picker             # https://docs.travis-ci.com/user/languages/objective-c#Build-Matrix
+xcode_sdk: iphonesimulator                # iphonesimulator9.3
+before_install:
+  - brew update
+  - brew outdated xctool || brew upgrade xctool
+  - xctool version
 script:
-- xcodebuild -project "Contacts Picker.xcodeproj" -scheme "Contacts Picker" -sdk iphonesimulator build test
+  - xctool test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ xcode_project: Contacts Picker.xcodeproj  # https://docs.travis-ci.com/user/lang
 xcode_scheme: Contacts Picker             # https://docs.travis-ci.com/user/languages/objective-c#Build-Matrix
 xcode_sdk: iphonesimulator                # iphonesimulator9.3
 before_install:
-  - brew update
-  - brew reinstall --HEAD xctool
-  - xctool version
+  - xcodebuild -version
 script:
-  - xctool clean build
-  - xctool test -test-sdk iphonesimulator -resetSimulator
+  - set -o pipefail
+  - COMMAND="xcodebuild -project \"$TRAVIS_XCODE_PROJECT\" -scheme \"$TRAVIS_XCODE_SCHEME\" -destination \"platform=iOS Simulator,name=iPhone 6s,OS=9.3\""
+  - eval $COMMAND clean build &>/dev/null
+  - eval $COMMAND test | xcpretty

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ xcode_scheme: Contacts Picker             # https://docs.travis-ci.com/user/lang
 xcode_sdk: iphonesimulator                # iphonesimulator9.3
 before_install:
   - brew update
-  - brew outdated xctool || brew upgrade xctool
+  - brew reinstall --HEAD xctool
   - xctool version
 script:
+  - xctool clean build
   - xctool test

--- a/.xctool-args
+++ b/.xctool-args
@@ -1,0 +1,6 @@
+[
+	"-project", "Contacts Picker.xcodeproj",
+	"-scheme", "Contacts Picker",
+	"-sdk", "iphonesimulator",
+	"-destination", "platform=iOS Simulator,name=iPhone 6s,OS=latest",
+]

--- a/Contacts Picker.xcodeproj/project.pbxproj
+++ b/Contacts Picker.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		4B7552C01CD28ADA00C638F1 /* .travis.yml */ = {isa = PBXFileReference; lastKnownFileType = text; path = .travis.yml; sourceTree = "<group>"; };
 		F4C1C93E1BDF8AB7001AA643 /* Contacts Picker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Contacts Picker.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F4C1C9411BDF8AB7001AA643 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		F4C1C9481BDF8AB7001AA643 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -71,6 +72,7 @@
 		F4C1C9351BDF8AB7001AA643 = {
 			isa = PBXGroup;
 			children = (
+				4B7552C01CD28ADA00C638F1 /* .travis.yml */,
 				F4C1C9401BDF8AB7001AA643 /* Contacts Picker */,
 				F4C1C9551BDF8AB7001AA643 /* Contacts PickerTests */,
 				F4C1C93F1BDF8AB7001AA643 /* Products */,


### PR DESCRIPTION
This change is to use xcodebuild on travis with xcpretty instead of default xctool.

I've tried using xctool, even HEAD version, but it caused travis build to hang while launching tests.
See more details: https://github.com/facebook/componentkit/pull/539
