### PR TITLE
Swift 2.3, fixed crash bugs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c                     # https://docs.travis-ci.com/user/languages/objective-c
-osx_image: xcode7.3                       # https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-7.3
+osx_image: xcode8                       # https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-7.3
 xcode_project: Contacts Picker.xcodeproj  # https://docs.travis-ci.com/user/languages/objective-c#Default-Test-Script
 xcode_scheme: Contacts Picker             # https://docs.travis-ci.com/user/languages/objective-c#Build-Matrix
 xcode_sdk: iphonesimulator                # iphonesimulator9.3

--- a/Contacts Picker.xcodeproj/project.pbxproj
+++ b/Contacts Picker.xcodeproj/project.pbxproj
@@ -174,9 +174,11 @@
 				TargetAttributes = {
 					F4C1C93D1BDF8AB7001AA643 = {
 						CreatedOnToolsVersion = 7.0;
+						LastSwiftMigration = 0800;
 					};
 					F4C1C9511BDF8AB7001AA643 = {
 						CreatedOnToolsVersion = 7.0;
+						LastSwiftMigration = 0800;
 						TestTargetID = F4C1C93D1BDF8AB7001AA643;
 					};
 				};
@@ -365,6 +367,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.prabaharan.eppicker.Contacts-Picker";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -376,6 +379,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.prabaharan.eppicker.Contacts-Picker";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};
@@ -387,6 +391,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.prabaharan.eppicker.Contacts-PickerTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Contacts Picker.app/Contacts Picker";
 			};
 			name = Debug;
@@ -399,6 +404,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.prabaharan.eppicker.Contacts-PickerTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Contacts Picker.app/Contacts Picker";
 			};
 			name = Release;

--- a/EPContactsPicker.podspec
+++ b/EPContactsPicker.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "EPContactsPicker"
-  s.version          = "1.0.6"
+  s.version          = "1.0.8"
   s.summary          = "A contacts picker component for iOS written in swift using new contacts framwork"
   s.description      = <<-DESC
 Features

--- a/Pods/EPConstants.swift
+++ b/Pods/EPConstants.swift
@@ -15,8 +15,8 @@ struct EPGlobalConstants {
     struct Strings {
         static let birdtdayDateFormat = "MMM d"
         static let contactsTitle = "Contacts"
-        static let phoneNumberNotAvaialable = "No phone numbers available!!"
-        static let emailNotAvaialable = "No emails available!!"
+        static let phoneNumberNotAvaialable = "No phone numbers available"
+        static let emailNotAvaialable = "No emails available"
         static let bundleIdentifier = "EPContactsPicker"
         static let cellNibIdentifier = "EPContactCell"
     }

--- a/Pods/EPContact.swift
+++ b/Pods/EPContact.swift
@@ -53,17 +53,21 @@ public class EPContact: NSObject {
             birthdayString = dateFormatter.stringFromDate(birthday!)
         }
         
-        for phoneNumber in contact.phoneNumbers {
-            let phone = phoneNumber.value as! CNPhoneNumber
-            phoneNumbers.append((phone.stringValue,phoneNumber.label))
-        }
-
-        for emailAddress in contact.emailAddresses {
-            let email = emailAddress.value as! String
-            emails.append((email,emailAddress.label))
-        }
+		for phoneNumber in contact.phoneNumbers {
+			guard let phone = phoneNumber.value as? CNPhoneNumber,
+				let phoneLabel = phoneNumber.label else { continue }
+			
+			phoneNumbers.append((phone.stringValue,phoneLabel))
+		}
+		
+		for emailAddress in contact.emailAddresses {
+			guard let email = emailAddress.value as? String,
+				let emailLabel = emailAddress.label else { continue }
+			
+			emails.append((email,emailLabel))
+		}
     }
-    
+	
     public func displayName() -> String {
         return "\(firstName) \(lastName)"
     }

--- a/Pods/EPContactsPicker.swift
+++ b/Pods/EPContactsPicker.swift
@@ -289,8 +289,12 @@ public class EPContactsPicker: UITableViewController, UISearchResultsUpdating, U
         }
         else {
             //Single selection code
-            contactDelegate?.epContactPicker(self, didSelectContact: selectedContact)
-            self.dismissViewControllerAnimated(true, completion: nil)
+			resultSearchController.active = false
+			self.dismissViewControllerAnimated(true, completion: {
+				dispatch_async(dispatch_get_main_queue()) {
+					self.contactDelegate?.epContactPicker(self, didSelectContact: selectedContact)
+				}
+			})
         }
     }
     

--- a/Pods/EPContactsPicker.swift
+++ b/Pods/EPContactsPicker.swift
@@ -10,12 +10,18 @@ import UIKit
 import Contacts
 
 
-@objc public protocol EPPickerDelegate {
-    optional    func epContactPicker(_: EPContactsPicker, didContactFetchFailed error: NSError)
-    optional    func epContactPicker(_: EPContactsPicker, didCancel error: NSError)
-    optional    func epContactPicker(_: EPContactsPicker, didSelectContact contact: EPContact)
-    optional    func epContactPicker(_: EPContactsPicker, didSelectMultipleContacts contacts: [EPContact])
+public protocol EPPickerDelegate {
+	func epContactPicker(_: EPContactsPicker, didContactFetchFailed error: NSError)
+    func epContactPicker(_: EPContactsPicker, didCancel error: NSError)
+    func epContactPicker(_: EPContactsPicker, didSelectContact contact: EPContact)
+	func epContactPicker(_: EPContactsPicker, didSelectMultipleContacts contacts: [EPContact])
+}
 
+public extension EPPickerDelegate {
+	func epContactPicker(_: EPContactsPicker, didContactFetchFailed error: NSError) { }
+	func epContactPicker(_: EPContactsPicker, didCancel error: NSError) { }
+	func epContactPicker(_: EPContactsPicker, didSelectContact contact: EPContact) { }
+	func epContactPicker(_: EPContactsPicker, didSelectMultipleContacts contacts: [EPContact]) { }
 }
 
 typealias ContactsHandler = (contacts : [CNContact] , error : NSError?) -> Void
@@ -151,7 +157,7 @@ public class EPContactsPicker: UITableViewController, UISearchResultsUpdating, U
                 
                 let alert = UIAlertController(title: "Unable to access contacts", message: "\(productName) does not have access to contacts. Kindly enable it in privacy settings ", preferredStyle: UIAlertControllerStyle.Alert)
                 let okAction = UIAlertAction(title: "Ok", style: UIAlertActionStyle.Default, handler: {  action in
-                    self.contactDelegate?.epContactPicker!(self, didContactFetchFailed: error)
+                    self.contactDelegate?.epContactPicker(self, didContactFetchFailed: error)
                     completion(contacts: [], error: error)
                     self.dismissViewControllerAnimated(true, completion: nil)
                 })
@@ -283,7 +289,7 @@ public class EPContactsPicker: UITableViewController, UISearchResultsUpdating, U
         }
         else {
             //Single selection code
-            contactDelegate?.epContactPicker!(self, didSelectContact: selectedContact)
+            contactDelegate?.epContactPicker(self, didSelectContact: selectedContact)
             self.dismissViewControllerAnimated(true, completion: nil)
         }
     }
@@ -311,12 +317,12 @@ public class EPContactsPicker: UITableViewController, UISearchResultsUpdating, U
     // MARK: - Button Actions
     
     func onTouchCancelButton() {
-        contactDelegate?.epContactPicker!(self, didCancel: NSError(domain: "EPContactPickerErrorDomain", code: 2, userInfo: [ NSLocalizedDescriptionKey: "User Canceled Selection"]))
+        contactDelegate?.epContactPicker(self, didCancel: NSError(domain: "EPContactPickerErrorDomain", code: 2, userInfo: [ NSLocalizedDescriptionKey: "User Canceled Selection"]))
         dismissViewControllerAnimated(true, completion: nil)
     }
     
     func onTouchDoneButton() {
-        contactDelegate?.epContactPicker!(self, didSelectMultipleContacts: selectedContacts)
+        contactDelegate?.epContactPicker(self, didSelectMultipleContacts: selectedContacts)
         dismissViewControllerAnimated(true, completion: nil)
     }
     

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Contacts picker component using new contacts framework by apple
 
 
 [![Platform](https://img.shields.io/cocoapods/p/EPContactsPicker.svg?style=flat)](http://cocoapods.org/pods/EPContactsPicker)
-[![Swift 2.2](https://img.shields.io/badge/Swift-2.2-orange.svg?style=flat)](https://developer.apple.com/swift/)
+[![Swift 2.3](https://img.shields.io/badge/Swift-2.3-orange.svg?style=flat)](https://developer.apple.com/swift/)
 [![CocoaPods Compatible](https://img.shields.io/cocoapods/v/EPContactsPicker.svg?style=flat)](http://cocoadocs.org/docsets/EPContactsPicker)
 [![CI Status](https://travis-ci.org/ipraba/EPContactsPicker.svg?branch=master)](https://travis-ci.org/ipraba/EPContactsPicker)
 [![License](https://img.shields.io/cocoapods/l/Ouroboros.svg?style=flat)](https://github.com/ipraba/EPContactsPicker/blob/master/LICENSE)


### PR DESCRIPTION
1. Fixed crash on Cancel button click after using search: it’s better to use native Swift protocol optional attribute via extensions.
2. Fixed bug when view controller wasn't dismissed while searchController is active: Search controller generates new view and adds it to navigation stack, so simple self.dismissViewController is not working, we need to deactivate searchController first (it is the one of approaches).

Also it’s better to call delegates after view is dismissed on my mind, because many people may call segues or animations after receiving delegate. And if your dismiss animation will be in process that will provide unexpected behavior. But that is up to you to decide.

Close #25