### PR TITLE
Feature/add should add contact block

### DIFF
--- a/Pods/EPContactsPicker.swift
+++ b/Pods/EPContactsPicker.swift
@@ -50,7 +50,11 @@ open class EPContactsPicker: UITableViewController, UISearchResultsUpdating, UIS
     var multiSelectEnabled: Bool = false //Default is single selection contact
     
     //Enables custom filtering of contacts.
-    public var shouldAddContact: ((CNContact) -> Bool)?
+    public var shouldAddContact: ((CNContact) -> Bool)? {
+        didSet {
+            self.reloadContacts()
+        }
+    }
     
     // MARK: - Lifecycle Methods
     

--- a/Pods/EPContactsPicker.swift
+++ b/Pods/EPContactsPicker.swift
@@ -49,6 +49,9 @@ open class EPContactsPicker: UITableViewController, UISearchResultsUpdating, UIS
     var subtitleCellValue = SubtitleCellValue.phoneNumber
     var multiSelectEnabled: Bool = false //Default is single selection contact
     
+    //Enables custom filtering of contacts.
+    public var shouldAddContact: ((CNContact) -> Bool)?
+    
     // MARK: - Lifecycle Methods
     
     override open func viewDidLoad() {
@@ -186,8 +189,19 @@ open class EPContactsPicker: UITableViewController, UISearchResultsUpdating, UIS
                 
                 do {
                     try contactsStore?.enumerateContacts(with: contactFetchRequest, usingBlock: { (contact, stop) -> Void in
+                        
+                        //Adds the `contact` to the `contactsArray` if the closure returns true. 
+                        //If the closure doesn't exist, then the contact is added.
+                        if let shouldAddContactClosure = self.shouldAddContact {
+                            if shouldAddContactClosure(contact) {
+                                contactsArray.append(contact)
+                            }
+                            
+                        } else {
+                            contactsArray.append(contact)
+                        }
+                        
                         //Ordering contacts based on alphabets in firstname
-                        contactsArray.append(contact)
                         var key: String = "#"
                         //If ordering has to be happening via family name change it here.
                         if let firstLetter = contact.givenName[0..<1] , firstLetter.containsAlphabets() {


### PR DESCRIPTION
After working with this library, I realized that I needed a way to filter the contacts based on the the values they had for certain `CNKeyDescriptor`'s. For example, say an app needs to only import contacts which have a valid phone number. By setting the `shouldAddContact` closure to return `true` when the phone number for a contact is valid, then you can be sure  that the `contacts` the user can pick from will all have valid phone numbers.