### PR TITLE
Implicitly unwrapped emojis cause crash.

### DIFF
--- a/Pods/EPExtensions.swift
+++ b/Pods/EPExtensions.swift
@@ -25,6 +25,9 @@ extension String {
     func containsAlphabets() -> Bool {
         //Checks if all the characters inside the string are alphabets
         let set = CharacterSet.letters
-        return self.utf16.contains( where: { return set.contains(UnicodeScalar($0)!)  } )
+        return self.utf16.contains( where: {
+            guard let unicode = UnicodeScalar($0) else { return false }
+            return set.contains(unicode)
+        })
     }
 }


### PR DESCRIPTION
When the first letter of a contacts name is an emoji the application crashes because the implicitly unwrapped `UnicodeScalar` returns nil. The `contains` function now returns false if the `UnicodeScalar` is nil`