### PR TITLE
New Features: ability to filter contacts + ability to set the maximum number of contacts to pick

### DIFF
--- a/Contacts Picker/ViewController.swift
+++ b/Contacts Picker/ViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import Contacts
 
 class ViewController: UIViewController, EPPickerDelegate {
 
@@ -22,7 +23,7 @@ class ViewController: UIViewController, EPPickerDelegate {
 
   @IBAction func onTouchShowMeContactsButton(_ sender: AnyObject) {
     
-    let contactPickerScene = EPContactsPicker(delegate: self, multiSelection:true, subtitleCellType: SubtitleCellValue.email)
+    let contactPickerScene = EPContactsPicker(delegate: self, multiSelection:true, subtitleCellType: SubtitleCellValue.phoneNumber)
     let navigationController = UINavigationController(rootViewController: contactPickerScene)
     self.present(navigationController, animated: true, completion: nil)
     
@@ -49,6 +50,10 @@ class ViewController: UIViewController, EPPickerDelegate {
         for contact in contacts {
             print("\(contact.displayName())")
         }
+    }
+    
+    func epContactPicker(_: EPContactsPicker, shouldAddContact contact: EPContact) -> Bool {
+        return contact.hasPhoneNumbers()
     }
 
 }

--- a/Contacts Picker/ViewController.swift
+++ b/Contacts Picker/ViewController.swift
@@ -23,7 +23,8 @@ class ViewController: UIViewController, EPPickerDelegate {
 
   @IBAction func onTouchShowMeContactsButton(_ sender: AnyObject) {
     
-    let contactPickerScene = EPContactsPicker(delegate: self, multiSelection:true, subtitleCellType: SubtitleCellValue.phoneNumber)
+//    let contactPickerScene = EPContactsPicker(delegate: self, multiSelection:true, subtitleCellType: SubtitleCellValue.phoneNumber)
+    let contactPickerScene = EPContactsPicker(delegate: self, multiSelection: true, multiSelectionLimit: 2)
     let navigationController = UINavigationController(rootViewController: contactPickerScene)
     self.present(navigationController, animated: true, completion: nil)
     

--- a/Pods/EPContact.swift
+++ b/Pods/EPContact.swift
@@ -67,6 +67,14 @@ open class EPContact {
         return firstName + " " + lastName
     }
     
+    open func hasPhoneNumbers() -> Bool {
+        return phoneNumbers.count > 0
+    }
+    
+    open func hasEmails() -> Bool {
+        return emails.count > 0
+    }
+    
     open func contactInitials() -> String {
         var initials = String()
 		

--- a/Pods/EPContactsPicker.swift
+++ b/Pods/EPContactsPicker.swift
@@ -56,7 +56,11 @@ open class EPContactsPicker: UITableViewController, UISearchResultsUpdating, UIS
     
     override open func viewDidLoad() {
         super.viewDidLoad()
-        self.title = EPGlobalConstants.Strings.contactsTitle
+        
+        
+        if self.title == nil {
+            self.title = EPGlobalConstants.Strings.contactsTitle
+        }
 
         registerContactCell()
         inititlizeBarButtons()
@@ -227,7 +231,7 @@ open class EPContactsPicker: UITableViewController, UISearchResultsUpdating, UIS
                             contacts.append(epContact)
                             
                             self.orderedContacts[key] = contacts
-                        }                        
+                        }
                     })
                     
                     

--- a/Pods/EPContactsPicker.swift
+++ b/Pods/EPContactsPicker.swift
@@ -207,27 +207,27 @@ open class EPContactsPicker: UITableViewController, UISearchResultsUpdating, UIS
                 
                 do {
                     try contactsStore?.enumerateContacts(with: contactFetchRequest, usingBlock: { (contact, stop) -> Void in
-                        //Ordering contacts based on alphabets in firstname
-                        contactsArray.append(contact)
-                        var key: String = "#"
-                        //If ordering has to be happening via family name change it here.
-                        if let firstLetter = contact.givenName[0..<1] , firstLetter.containsAlphabets() {
-                            key = firstLetter.uppercased()
-                        }
-                        var contacts = [EPContact]()
-                        
-                        if let segregatedContact = self.orderedContacts[key] {
-                            contacts = segregatedContact
-                        }
                         
                         let epContact = EPContact.init(contact: contact)
                         
-                        if (self.contactDelegate?.epContactPicker(self, shouldAddContact: epContact) == true){
+                        if (self.contactDelegate?.epContactPicker(self, shouldAddContact: epContact)) == true {
+                            //Ordering contacts based on alphabets in firstname
+                            contactsArray.append(contact)
+                            var key: String = "#"
+                            //If ordering has to be happening via family name change it here.
+                            if let firstLetter = contact.givenName[0..<1] , firstLetter.containsAlphabets() {
+                                key = firstLetter.uppercased()
+                            }
+                            var contacts = [EPContact]()
+                            
+                            if let segregatedContact = self.orderedContacts[key] {
+                                contacts = segregatedContact
+                            }
+                            
                             contacts.append(epContact)
-                        }
-                        
-                        self.orderedContacts[key] = contacts
-
+                            
+                            self.orderedContacts[key] = contacts
+                        }                        
                     })
                     
                     

--- a/Pods/EPContactsPicker.swift
+++ b/Pods/EPContactsPicker.swift
@@ -50,6 +50,7 @@ open class EPContactsPicker: UITableViewController, UISearchResultsUpdating, UIS
     
     var subtitleCellValue = SubtitleCellValue.phoneNumber
     var multiSelectEnabled: Bool = false //Default is single selection contact
+    var multiSelectContactLimit : UInt = 0
     
     // MARK: - Lifecycle Methods
     
@@ -122,14 +123,30 @@ open class EPContactsPicker: UITableViewController, UISearchResultsUpdating, UIS
     convenience public init(delegate: EPPickerDelegate?, multiSelection : Bool) {
         self.init(style: .plain)
         self.multiSelectEnabled = multiSelection
-        contactDelegate = delegate
+        self.contactDelegate = delegate
     }
 
     convenience public init(delegate: EPPickerDelegate?, multiSelection : Bool, subtitleCellType: SubtitleCellValue) {
         self.init(style: .plain)
         self.multiSelectEnabled = multiSelection
-        contactDelegate = delegate
-        subtitleCellValue = subtitleCellType
+        self.contactDelegate = delegate
+        self.subtitleCellValue = subtitleCellType
+    }
+    
+    convenience public init(delegate: EPPickerDelegate?, multiSelection : Bool, multiSelectionLimit: UInt) {
+    
+        self.init(style: .plain)
+        self.multiSelectEnabled = multiSelection
+        self.multiSelectContactLimit = multiSelectionLimit
+        self.contactDelegate = delegate
+    }
+    
+    convenience public init(delegate: EPPickerDelegate?, multiSelection : Bool, multiSelectionLimit: UInt, subtitleCellType: SubtitleCellValue) {
+        self.init(style: .plain)
+        self.multiSelectEnabled = multiSelection
+        self.multiSelectContactLimit = multiSelectionLimit
+        self.subtitleCellValue = subtitleCellType
+        self.contactDelegate = delegate
     }
     
     
@@ -299,7 +316,7 @@ open class EPContactsPicker: UITableViewController, UISearchResultsUpdating, UIS
                     return selectedContact.contactId != $0.contactId
                 }
             }
-            else {
+            else if (self.multiSelectContactLimit == 0 || self.selectedContacts.count < Int(self.multiSelectContactLimit)) {
                 cell.accessoryType = UITableViewCellAccessoryType.checkmark
                 selectedContacts.append(selectedContact)
             }
@@ -373,7 +390,10 @@ open class EPContactsPicker: UITableViewController, UISearchResultsUpdating, UIS
                 filteredContacts.removeAll()
                 
                 for contact in unifiedContacts {
-                    filteredContacts.append(EPContact.init(contact: contact))
+                    let epContact = EPContact.init(contact: contact)
+                    if (self.contactDelegate?.epContactPicker(self, shouldAddContact: epContact) == true){
+                        filteredContacts.append(EPContact.init(contact: contact))
+                    }
                 }
                 
                 self.tableView.reloadData()


### PR DESCRIPTION
This pull request contain 2 new features for this library:

1. **Ability to filter contacts** - 
since the default **CNContactStore** does not allow to create custom NSPredicate via  **CNContactFetchRequest** i've added a new delegate method that will be called in each iteration inside the **enumerateContacts** in this delegate method the user can decide if the given contact should be added or not to the results. In order to use you simply override the: 

`func epContactPicker(_: EPContactsPicker, shouldAddContact contact: EPContact) -> Bool`

method in the delegate and there write the code which determine if the contact should be added to the results or not. This method return a boolean if its **true** the contact will be added otherwise it will be ignored. By default all contact will be added to the result set.

2. **Set maximum number of picked contacts** - I've introduce 2 new init methods which allows you to set the max number of contact that the user can select (works in multi selection mode only).

setting this value can be done in one of the following init methods:

```
convenience public init(delegate: EPPickerDelegate?, multiSelection : Bool, multiSelectionLimit: UInt)

convenience public init(delegate: EPPickerDelegate?, multiSelection : Bool, multiSelectionLimit: UInt, subtitleCellType: SubtitleCellValue)
```