### PR TITLE
Show contacts with empty email's label

### DIFF
--- a/Pods/EPContact.swift
+++ b/Pods/EPContact.swift
@@ -56,7 +56,7 @@ open class EPContact {
 		}
 		
 		for emailAddress in contact.emailAddresses {
-			guard let emailLabel = emailAddress.label else { continue }
+			let emailLabel = emailAddress.label ?? "email"
 			let email = emailAddress.value as String
 			
 			emails.append((email,emailLabel))

--- a/Pods/EPContact.swift
+++ b/Pods/EPContact.swift
@@ -46,10 +46,10 @@ open class EPContact {
         }
         
 		for phoneNumber in contact.phoneNumbers {
-            		var phoneLabel = "phone"
-            		if let label = phoneNumber.label {
-            		    phoneLabel = label
-            		}
+            var phoneLabel = "phone"
+            if let label = phoneNumber.label {
+                phoneLabel = label
+            }
 			let phone = phoneNumber.value.stringValue
 			
 			phoneNumbers.append((phone,phoneLabel))

--- a/Pods/EPContact.swift
+++ b/Pods/EPContact.swift
@@ -37,7 +37,6 @@ open class EPContact {
         }
         
         if let birthdayDate = contact.birthday {
-            
             birthday = Calendar(identifier: Calendar.Identifier.gregorian).date(from: birthdayDate)
             let dateFormatter = DateFormatter()
             dateFormatter.dateFormat = EPGlobalConstants.Strings.birdtdayDateFormat
@@ -45,22 +44,22 @@ open class EPContact {
             birthdayString = dateFormatter.string(from: birthday!)
         }
         
-		for phoneNumber in contact.phoneNumbers {
+        for phoneNumber in contact.phoneNumbers {
             var phoneLabel = "phone"
             if let label = phoneNumber.label {
                 phoneLabel = label
             }
-			let phone = phoneNumber.value.stringValue
-			
-			phoneNumbers.append((phone,phoneLabel))
-		}
-		
-		for emailAddress in contact.emailAddresses {
-			let emailLabel = emailAddress.label ?? "email"
-			let email = emailAddress.value as String
-			
-			emails.append((email,emailLabel))
-		}
+            let phone = phoneNumber.value.stringValue
+            
+            phoneNumbers.append((phone,phoneLabel))
+        }
+        
+        for emailAddress in contact.emailAddresses {
+            let emailLabel = emailAddress.label ?? "email"
+            let email = emailAddress.value as String
+            
+            emails.append((email,emailLabel))
+        }
     }
 	
     open func displayName() -> String {


### PR DESCRIPTION
I am working with mail service such as Exchange, etc. And I imported all contacts from Exchange to phone's contact list. By default, email's label is empty for these contacts. I suggest using default label as "email" for that.  