### PR TITLE
Remove the necessity to tap on "Done" button twice

### DIFF
--- a/Pods/EPContactsPicker.swift
+++ b/Pods/EPContactsPicker.swift
@@ -333,6 +333,9 @@ open class EPContactsPicker: UITableViewController, UISearchResultsUpdating, UIS
     }
     
     func onTouchDoneButton() {
+        if resultSearchController.isActive {
+            resultSearchController.dismiss(animated: false, completion: nil)
+        }
         dismiss(animated: true, completion: {
             self.contactDelegate?.epContactPicker(self, didSelectMultipleContacts: self.selectedContacts)
         })


### PR DESCRIPTION
I suggest removing the necessity to tap on "Done" button twice when the search mode is active.