### PR TITLE
Show contacts with empty email's label

### DIFF
--- a/Pods/EPContact.swift
+++ b/Pods/EPContact.swift
@@ -56,7 +56,7 @@ open class EPContact {
 		}
 		
 		for emailAddress in contact.emailAddresses {
-			guard let emailLabel = emailAddress.label else { continue }
+			let emailLabel = emailAddress.label ?? "email"
 			let email = emailAddress.value as String
 			
 			emails.append((email,emailLabel))

--- a/Pods/EPContact.swift
+++ b/Pods/EPContact.swift
@@ -46,10 +46,10 @@ open class EPContact {
         }
         
 		for phoneNumber in contact.phoneNumbers {
-            		var phoneLabel = "phone"
-            		if let label = phoneNumber.label {
-            		    phoneLabel = label
-            		}
+            var phoneLabel = "phone"
+            if let label = phoneNumber.label {
+                phoneLabel = label
+            }
 			let phone = phoneNumber.value.stringValue
 			
 			phoneNumbers.append((phone,phoneLabel))


### PR DESCRIPTION
I am working with mail services such as Exchange, etc. And I imported all contacts from Exchange to phone's contact list. By default, email's label is empty for these contacts. I suggest using default label as "email" for that.