### PR TITLE
Add Deselection of Contact to Protocol + Goodies

### DIFF
--- a/Pods/EPContactsPicker.swift
+++ b/Pods/EPContactsPicker.swift
@@ -49,6 +49,9 @@ open class EPContactsPicker: UITableViewController, UISearchResultsUpdating, UIS
     var subtitleCellValue = SubtitleCellValue.phoneNumber
     var multiSelectEnabled: Bool = false //Default is single selection contact
     
+    // Customizable
+    var contactsAccessMessage: String? /// This is the message that the user will see when we need to request access for contacts
+    
     // MARK: - Lifecycle Methods
     
     override open func viewDidLoad() {
@@ -155,8 +158,11 @@ open class EPContactsPicker: UITableViewController, UISearchResultsUpdating, UIS
                 //User has denied the current app to access the contacts.
                 
                 let productName = Bundle.main.infoDictionary!["CFBundleName"]!
-                
-                let alert = UIAlertController(title: "Unable to access contacts", message: "\(productName) does not have access to contacts. Kindly enable it in privacy settings ", preferredStyle: UIAlertControllerStyle.alert)
+                var message: String = "\(productName) does not have access to contacts. Kindly enable it in privacy settings."
+                if(self.contactsAccessMessage != nil) {
+                    message = self.contactsAccessMessage!
+                }
+                let alert = UIAlertController(title: "Unable to access contacts", message: message, preferredStyle: UIAlertControllerStyle.alert)
                 let okAction = UIAlertAction(title: "Ok", style: UIAlertActionStyle.default, handler: {  action in
                     completion([], error)
                     self.dismiss(animated: true, completion: {
@@ -164,6 +170,10 @@ open class EPContactsPicker: UITableViewController, UISearchResultsUpdating, UIS
                     })
                 })
                 alert.addAction(okAction)
+                // Quick link for the user to reach the app's settings.
+                alert.addAction(UIAlertAction(title: "Open Settings", style: .default) { action in
+                    UIApplication.shared.openURL(URL(string: UIApplicationOpenSettingsURLString)!)
+                })
                 self.present(alert, animated: true, completion: nil)
             
             case CNAuthorizationStatus.notDetermined:

--- a/Pods/EPContactsPicker.swift
+++ b/Pods/EPContactsPicker.swift
@@ -50,7 +50,7 @@ open class EPContactsPicker: UITableViewController, UISearchResultsUpdating, UIS
     var multiSelectEnabled: Bool = false //Default is single selection contact
     
     // Customizable
-    var contactsAccessMessage: String? /// This is the message that the user will see when we need to request access for contacts
+    public var contactsAccessMessage: String? /// This is the message that the user will see when we need to request access for contacts
     
     // MARK: - Lifecycle Methods
     

--- a/Pods/EPContactsPicker.swift
+++ b/Pods/EPContactsPicker.swift
@@ -14,6 +14,7 @@ public protocol EPPickerDelegate: class {
 	func epContactPicker(_: EPContactsPicker, didContactFetchFailed error: NSError)
     func epContactPicker(_: EPContactsPicker, didCancel error: NSError)
     func epContactPicker(_: EPContactsPicker, didSelectContact contact: EPContact)
+    func epContactPicker(_: EPContactsPicker, didDeselectContact contact: EPContact)
 	func epContactPicker(_: EPContactsPicker, didSelectMultipleContacts contacts: [EPContact])
 }
 
@@ -133,6 +134,13 @@ open class EPContactsPicker: UITableViewController, UISearchResultsUpdating, UIS
         subtitleCellValue = subtitleCellType
     }
     
+    convenience public init(delegate: EPPickerDelegate?, multiSelection : Bool, subtitleCellType: SubtitleCellValue, selectedContacts: [EPContact]) {
+        self.init(style: .plain)
+        self.multiSelectEnabled = multiSelection
+        self.contactDelegate = delegate
+        self.subtitleCellValue = subtitleCellType
+        self.selectedContacts = selectedContacts
+    }
     
     // MARK: - Contact Operations
   
@@ -294,6 +302,7 @@ open class EPContactsPicker: UITableViewController, UISearchResultsUpdating, UIS
             //Keeps track of enable=ing and disabling contacts
             if cell.accessoryType == UITableViewCellAccessoryType.checkmark {
                 cell.accessoryType = UITableViewCellAccessoryType.none
+                self.contactDelegate?.epContactPicker(self, didDeselectContact: selectedContact)
                 selectedContacts = selectedContacts.filter(){
                     return selectedContact.contactId != $0.contactId
                 }


### PR DESCRIPTION
• Add capability to deselect a contact and to notify the delegate when this happens.
• Ability to customize the alert message when user has not given app permission to access contacts.
• Addition of UIAlertAction to alert message that takes the user to the app's settings to give app access to contacts.